### PR TITLE
Wire up cell selection from Dash

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,24 @@ if os.path.exists(PROCESSED_FILE):
 
 # === Placeholder for LLaVA-style multimodal model ===
 def run_model(selected_cells, question, history):
-    return f"(Placeholder) You asked: '{question}' about {len(selected_cells)} selected cells."
+    return (
+        f"(Placeholder) You asked: '{question}' about "
+        f"{len(selected_cells)} selected cells."
+    )
+
+# Store cell selections coming from visualization tools
+current_selection = []
+
+
+@app.route("/selection", methods=["GET", "POST"])
+def selection():
+    """Store or retrieve the currently selected cell IDs."""
+    global current_selection
+    if request.method == "POST":
+        data = request.get_json() or {}
+        current_selection = data.get("cell_ids", [])
+        return "ok"
+    return jsonify({"cell_ids": current_selection})
 
 @app.route("/")
 def index():

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -217,6 +217,16 @@
       ).join("<hr>");
     }
 
+    async function fetchSelection() {
+      try {
+        const res = await fetch('/selection');
+        const data = await res.json();
+        document.getElementById('cell_ids').value = data.cell_ids.join('\n');
+      } catch (e) {
+        console.error('Failed to fetch selection', e);
+      }
+    }
+
     window.onload = function () {
       const stored = localStorage.getItem("chatHistory");
       if (stored) {
@@ -224,6 +234,9 @@
           renderChat(JSON.parse(stored));
         } catch {}
       }
+
+      fetchSelection();
+      setInterval(fetchSelection, 2000);
 
       document.getElementById("uploadForm").addEventListener("submit", async function (e) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- add `/selection` endpoint in Flask to store currently selected cell ids
- send selections from Dash `scExplorer` callback via `requests.post`
- poll `/selection` from the page to automatically fill in Q&A cell id box

## Testing
- `python -m py_compile app.py sc_explorer.py convert_h5ad.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c44731c80832f9f38e1494b6c6662