### PR TITLE
Switch default tab to scExplorer and tweak layout

### DIFF
--- a/sc_explorer.py
+++ b/sc_explorer.py
@@ -23,10 +23,16 @@ fig = px.scatter(
     hover_data=["cell_id"],
     custom_data=["cell_id"],
 )
+fig.update_layout(xaxis_scaleanchor="y")
 
 app.layout = html.Div([
     html.H2("scRNA-seq Explorer"),
-    dcc.Graph(id="umap", figure=fig),
+    dcc.Graph(
+        id="umap",
+        figure=fig,
+        style={"height": "80vh", "width": "100%"},
+        config={"responsive": True},
+    ),
     html.Div(id="selected-cells")
 ])
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -147,7 +147,7 @@
     }
 
     .split iframe {
-      flex: 3;
+      flex: 4;
     }
 
     .split .chat-box {
@@ -156,7 +156,7 @@
     }
   </style>
 </head>
-<body class="dark">
+<body class="light">
   <header class="container">
     🧬 Multimodal scRNA-seq Q&A Demo
     <button onclick="toggleTheme()">🌓 Toggle Theme</button>
@@ -164,15 +164,12 @@
 
   <div class="container">
   <div class="tabs">
-    <div class="tab active" onclick="showPanel(0)">🧭 UCSC Cell Browser</div>
-    <div class="tab" onclick="showPanel(1)">📊 scExplorer & 💬 Ask Granite.Biomed</div>
+    <div class="tab active" onclick="showPanel(0)">📊 scExplorer & 💬 Ask Granite.Biomed</div>
+    <div class="tab" onclick="showPanel(1)">🧭 UCSC Cell Browser</div>
     <div class="tab" onclick="showPanel(2)">📁 Upload .h5ad</div>
   </div>
 
   <div class="panel active">
-    <iframe src="http://127.0.0.1:8080/demo/index.html"></iframe>
-  </div>
-  <div class="panel">
     <div class="split">
       <iframe src="http://127.0.0.1:8050"></iframe>
       <div class="chat-box">
@@ -184,6 +181,9 @@
         <div id="chat">Waiting for your question...</div>
       </div>
     </div>
+  </div>
+  <div class="panel">
+    <iframe src="http://127.0.0.1:8080/demo/index.html"></iframe>
   </div>
   <div class="panel">
     <div class="chat-box">


### PR DESCRIPTION
## Summary
- default to light theme
- show scExplorer tab first and enlarge its width
- keep scExplorer scatter plot square and responsive

## Testing
- `python -m py_compile sc_explorer.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cad749114832f847758b7aae6f30f